### PR TITLE
Add the capability to recreate a collection without the documents

### DIFF
--- a/src/CosmosDbExplorer/MainWindow.xaml
+++ b/src/CosmosDbExplorer/MainWindow.xaml
@@ -557,11 +557,14 @@
                             </fluent:MenuItem.Icon>
                         </fluent:MenuItem>
 
-                        <fluent:MenuItem Header="Remove All Documents" 
+                        <fluent:MenuItem Header="Remove All Documents (Delete)" 
                                    Icon="{StaticResource RemoveAllIcon}" 
                                    Command="{Binding Collection.ClearAllDocumentsCommand}"
                                    />
-
+                        <fluent:MenuItem Header="Remove All Documents (Recreate)" 
+                                   Icon="{StaticResource RemoveAllIcon}" 
+                                   Command="{Binding Collection.RecreateAsEmptyCommand}"
+                                   />
                     </fluent:SplitButton>
 
                 </fluent:RibbonGroupBox>

--- a/src/CosmosDbExplorer/Services/IDocumentDbService.cs
+++ b/src/CosmosDbExplorer/Services/IDocumentDbService.cs
@@ -28,6 +28,8 @@ namespace CosmosDbExplorer.Services
 
         Task CleanCollectionAsync(Connection connection, DocumentCollection collection);
 
+        Task<DocumentCollection> RecreateCollectionAsync(Connection connection, Database database, DocumentCollection collection);
+
         Task<int> ImportDocumentAsync(Connection connection, DocumentCollection collection, string content, IHaveRequestOptions requestOptions, CancellationToken cancellationToken);
 
         Task<IList<StoredProcedure>> GetStoredProceduresAsync(Connection connection, DocumentCollection collection);

--- a/src/CosmosDbExplorer/ViewModel/DatabaseNodes/DatabaseNodeViewModel.cs
+++ b/src/CosmosDbExplorer/ViewModel/DatabaseNodes/DatabaseNodeViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using CosmosDbExplorer.Infrastructure;
-using CosmosDbExplorer.Services;
 using CosmosDbExplorer.Views;
 using GalaSoft.MvvmLight.Threading;
 using Microsoft.Azure.Documents;
@@ -9,25 +8,26 @@ namespace CosmosDbExplorer.ViewModel
 {
     public class DatabaseNodeViewModel : ResourceNodeViewModelBase<ConnectionNodeViewModel>
     {
-        private readonly Database _database;
         private RelayCommand _addNewCollectionCommand;
         private RelayCommand _deleteDatabaseCommand;
 
         public DatabaseNodeViewModel(Database database, ConnectionNodeViewModel parent)
             : base(database, parent, true)
         {
-            _database = database;
+            Database = database;
         }
+
+        public Database Database { get; }
 
         protected override async Task LoadChildren()
         {
             IsLoading = true;
 
-            var collections = await DbService.GetCollectionsAsync(Parent.Connection, _database).ConfigureAwait(false);
+            var collections = await DbService.GetCollectionsAsync(Parent.Connection, Database).ConfigureAwait(false);
 
             await DispatcherHelper.RunAsync(() =>
             {
-                Children.Add(new UsersNodeViewModel(_database, this));
+                Children.Add(new UsersNodeViewModel(Database, this));
                 foreach (var collection in collections)
                 {
                     Children.Add(new CollectionNodeViewModel(collection, this));
@@ -50,7 +50,7 @@ namespace CosmosDbExplorer.ViewModel
 
                             vm.Databases = Parent.Databases;
                             vm.Connection = Parent.Connection;
-                            vm.SelectedDatabase = _database.Id;
+                            vm.SelectedDatabase = Database.Id;
 
                             if (form.ShowDialog().GetValueOrDefault(false))
                             {
@@ -76,7 +76,7 @@ namespace CosmosDbExplorer.ViewModel
                                     if (confirm)
                                     {
                                         UIServices.SetBusyState(true);
-                                        await DbService.DeleteDatabaseAsync(Parent.Connection, _database).ConfigureAwait(true);
+                                        await DbService.DeleteDatabaseAsync(Parent.Connection, Database).ConfigureAwait(true);
                                         Parent.Children.Remove(this);
                                         UIServices.SetBusyState(false);
                                     }

--- a/src/CosmosDbExplorer/Views/DatabaseView.xaml
+++ b/src/CosmosDbExplorer/Views/DatabaseView.xaml
@@ -210,11 +210,19 @@
                             <Separator />
 
                             <MenuItem Header="Delete Collection" Command="{Binding DeleteCollectionCommand}" Icon="{StaticResource DeleteIconText}" />
-                            <MenuItem Header="Remove All Documents" Command="{Binding ClearAllDocumentsCommand}">
+
+                            <Separator />
+                            <MenuItem Header="Remove All Documents (Delete)" Command="{Binding ClearAllDocumentsCommand}">
                                 <MenuItem.Icon>
                                     <Image Source="{StaticResource RemoveAllIcon}" />
                                 </MenuItem.Icon>
                             </MenuItem>
+                            <MenuItem Header="Remove All Documents (Recreate)" Command="{Binding RecreateAsEmptyCommand}">
+                                <MenuItem.Icon>
+                                    <Image Source="{StaticResource RemoveAllIcon}" />
+                                </MenuItem.Icon>
+                            </MenuItem>
+
                             <Separator />
                             <MenuItem Header="Copy">
                                 <MenuItem.Icon>


### PR DESCRIPTION
If a collection has a lot of documents, it is then long and costly in term of RU to iterate the collection and delete each document one-by-one. 

This PR offers a new feature that re-create a collection with all it's content (SP, Triggers, UDF) and parameters (Throughput, Partition, etc), but without the document, 

It's a lot faster and doesn't cost much in term of RU. 